### PR TITLE
原神安装目录选择能够识别游戏本体安装路径

### DIFF
--- a/GenshinAccount/FormMain.cs
+++ b/GenshinAccount/FormMain.cs
@@ -261,6 +261,10 @@ namespace GenshinAccount
             dialog.Description = "请选择原神安装路径";
             if (dialog.ShowDialog() == DialogResult.OK)
             {
+                if(!string.IsNullOrEmpty(dialog.SelectedPath) && File.Exists(Path.Combine(dialog.SelectedPath, "YuanShen.exe")))
+                {
+                    dialog.SelectedPath = dialog.SelectedPath.Replace("Genshin Impact Game","");
+                }
                 if (string.IsNullOrEmpty(dialog.SelectedPath) || !File.Exists(Path.Combine(dialog.SelectedPath, "Genshin Impact Game", "YuanShen.exe")))
                 {
                     MessageBox.Show("无法在该文件夹中找到原神启动程序，请选择正确的原神安装路径!");


### PR DESCRIPTION
有些人的游戏安装位置和启动器安装位置不一样，如果选择了游戏安装位置就不能正确识别
我改成了如果选择了游戏安装位置之后就选中上一级目录